### PR TITLE
Add few tests for smtp settings

### DIFF
--- a/decidim-system/spec/commands/decidim/system/register_organization_spec.rb
+++ b/decidim-system/spec/commands/decidim/system/register_organization_spec.rb
@@ -115,7 +115,7 @@ module Decidim
                 organization = Organization.last
 
                 expect(organization.smtp_settings["from"]).to eq("decide@gotham.gov")
-                expect(organization.smtp_settings["from_email"]).to eq(organization.smtp_settings["from"])
+                expect(organization.smtp_settings["from_email"]).to eq("decide@gotham.gov")
               end
             end
           end

--- a/decidim-system/spec/forms/decidim/system/update_organization_form_spec.rb
+++ b/decidim-system/spec/forms/decidim/system/update_organization_form_spec.rb
@@ -22,7 +22,7 @@ module Decidim::System
           "user_name" => "f.laguardia",
           "password" => Decidim::AttributeEncryptor.encrypt("password"),
           "from_email" => "decide@gotham.gov",
-          "from_label" => "Decide Gotham"
+          "from_label" => from_label
         },
         omniauth_settings: {
           "omniauth_settings_facebook_enabled" => true,
@@ -32,6 +32,7 @@ module Decidim::System
       )
     end
 
+    let(:from_label) { "Decide Gotham" }
     let(:facebook_app_id) { "plain-text-facebook-app-id" }
     let(:facebook_app_secret) { "plain-text-facebook-app-secret" }
 
@@ -57,6 +58,24 @@ module Decidim::System
           expect(
             Decidim::AttributeEncryptor.decrypt(encrypted_settings["omniauth_settings_facebook_app_secret"])
           ).to eq(facebook_app_secret)
+        end
+      end
+
+      describe "#set_from" do
+        it "concatenates from_label and from_email" do
+          from = subject.set_from
+
+          expect(from).to eq("Decide Gotham <decide@gotham.gov>")
+        end
+
+        context "when from_label is empty" do
+          let(:from_label) { "" }
+
+          it "returns the email" do
+            from = subject.set_from
+
+            expect(from).to eq("decide@gotham.gov")
+          end
         end
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?

Add tests for `set_from` method in organization form when navigating on `/system`

#### :clipboard: Subtasks
- [x] Light refactor of `register_organization_spec`
- [x] Add tests for `set_from` methods
